### PR TITLE
Reorganized code, added events as functions, new version.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 2
+
+[*.{json,yml,md}]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -8,30 +8,58 @@ To install using bower:
 
 	bower install clubajax/on --save
 
-You may also use `npm` if you prefer. You can also clone the repository with your generic clone commands as a standalone 
+You may also use `npm` if you prefer. You can also clone the repository with your generic clone commands as a standalone
 repository or submodule.
-	  
+
 	git clone git://github.com/clubajax/on.git
-                                      
+
 It is recommended that you set the config.path of RequireJS to make `on` accessible as an absolute
 path. If using as a global or with Browserify, it is suggested that you use an *NPM run script* to
 copy the `on` script to a location more convenient for your project.
 
-`on` has a dependency on the very well-done [keyboardevent-key-polyfill](https://github.com/cvan/keyboardevent-key-polyfill),
-which provides a [`KeyboardEvent.key` property](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) in the event.
+`on` can work with the very well-done [keyboardevent-key-polyfill](https://github.com/cvan/keyboardevent-key-polyfill),
+which provides [KeyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) property in the event.
 
 ## Description
 
 `on` is a library for handling DOM node events in a simple way. It has been under development and used in
 production for years. The code is very well established, tested, and used in enterprise apps.
 
-The primary feature is it returns a handle, from which you can pause, resume, and remove the event.
+The primary feature is it returns a handle, from which you can pause, resume, and remove the event handler.
 Handles are much easier to manipulate than using `removeEventListener` or jQuery's `off`, which
 sometimes necessitates recreating sometimes complex or recursive function signatures.
 
+`on()` makes handling events easy, and supports directly several important techniques, like automatic binding
+of the same event handler to several events, event delegation, event filtering, and even creating synthetic
+events, like `"clickoff"` (user clicked outside of our element, e.g., a modal dialog), gestures, and so on.
+
+Supported signatures:
+
+* `handle = on(node, eventName, handler)`
+* `handle = on(node, eventName, filter, handler)`
+
+Following arguments are expected:
+
+* `node` &mdash; a DOM node to attach an event listener to, or its id (as a string).
+* `eventName` &mdash; an event name as a string, or a function, with following signature:
+  `handle = eventProcessor(domNode, callback)`, where:
+  * `domNode` &mdash; a DOM node.
+  * `callback` &mdash; an event handler function, which is usually a combination of `filter` and `handler`.
+* `filter` &mdash; an optional filter parameter, which can be:
+  * simple selector suitable for
+  [matches()](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches)
+  * function, which an event objects as single parameter, and returns a DOM node, which fits its criteria
+  (usually in a parent chain), or `null`, if its criteria was not satisfied.
+    * If a match was found it will be added to an event object as `filteredTarget`,
+      and additionally passed to an event handler as the second parameter.
+* `handler` &mdash; an event handler function, which takes an event object as its first parameter,
+  and an optional filtered DOM node as its second parameter.
+* `handle` &mdash; a returned object, which allows to control an event flow.
+
 Think of handles as something like a returned Promise - an object with methods, with which you can
 control the event handler.
-```jsx harmony
+
+```js
  var handle = on(node, 'click', function(event){
     console.log('click event:', event);
  });
@@ -39,14 +67,17 @@ control the event handler.
  handle.resume(); // click event fires again
  handle.remove(); // click event is permanently removed
 ```
+
 Events can be handled with any object from which you can attach events.
-```jsx harmony
+
+```js
 on(window, 'resize', onResize);
 on(image, 'load', onImageLoaded);
 on(input, 'keydown', onKey);
 ```
-`on.remove` is a very common feature, use for cleaning up events when destroying a widget.  
-`on.pause` is less common - used for turning functionality on and off, like for popups or mouse tracking.
+
+`on.remove` is a very common feature, used for cleaning up events when destroying a widget.
+`on.pause` is less common &mdash; used for turning functionality on and off, like for popups or mouse tracking.
 
 ## Browser Support
 
@@ -61,40 +92,25 @@ Node.js is not supported since this is a DOM-based library.
 ## Features
 
 ### The KeyboardEvent Key property
-The [KeyboardEvent key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent) property standardizes modern browsers 
-(Chrome 51+) and IE9-11 (which uses the key property, but from the old spec), 
+
+The [KeyboardEvent key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent) property standardizes modern browsers
+(Chrome 51+) and IE9-11 (which uses the key property, but from the old spec),
 which adds the actual letter or number pressed to the event, not just the key code.
 
 Because the creator of this library uses a Mac, by opinion, the keys are normalized to a Mac. So 'Win' maps to 'Command'
 and 'Alt' maps to 'Option'. All others should be intuitive.
 
-### clickoff
-There is a custom `clickoff` event, to detect if you've clicked anywhere in the document
-other than the passed node. Useful for menus and modals.
-```jsx harmony
- var handle = on(node, 'clickoff', callback);
- handle.resume();
- //  callback fires if something other than node is clicked
-```
-**NOTE** _a clickoff event starts paused due to potential side effects. You typically don't want the event
-to be listened to and fired until some other event has been triggered, like the opening of a modal._
+### Wheel Events
 
-### Multiple Event Types
-There is support for multiple event types at once. The following example is useful for handling
-both desktop mouseovers and tablet clicks:
-```jsx harmony
-var handle = on(node, 'mouseover,click', onStart);
-```
-### Multiple Key Events
-A special multi-event can be used to listen for certain key strokes:
-```jsx harmony
-on(input, 'keyup:Enter,Escape, ,Backspace', handler);
-on(input, 'keydown:a,b,c,d,A,B,C,D', handler);
-````
+Wheel events are normalized to a standard: `delta`, `wheelY`, `wheelX`.
+
+It also adds acceleration and deceleration to make Mac and Windows scroll wheels behave similarly.
 
 ### Filters
+
 `on` supports filtered selectors, as an additional parameter:
-```jsx harmony
+
+```js
 on(node, 'click', '.tab', callback);
 on(node, 'click', 'div', callback);
 on(node, 'click', '#main', callback);
@@ -103,39 +119,99 @@ on(node, 'click', 'div["data-foo"=bar]', callback);
 function callback (e, filtered) {
 	console.log('target:', e.filteredTarget)
 }
-````
+```
 
 So as not to override the event, the targeted element will be in the event as `filteredTarget` as well as
 the second argument in the callback.
 
-Typically, this technique is used on a node with child elements. The `filteredTarget` will always be the parent, and 
+Typically, this technique is used on a node with child elements. The `filteredTarget` will always be the parent, and
 not the child. Under the hood it uses `on.closest`, described below.
 
-### Wheel Events
-Wheel events are normalized to a standard:
-	
-	delta, wheelY, wheelX
-	
-It also adds acceleration and deceleration to make Mac and Windows scroll wheels behave similarly.
+### Multiple Event Types
+
+There is support for multiple event types at once. The following example is useful for handling
+both desktop mouseovers and tablet clicks:
+
+```js
+var handle = on(node, 'mouseover,click', onStart);
+```
+
+### Composite events
+
+Instead of an event name (a string), it is possible to specify a function. All other `on()` arguments
+will be normalized, and this function will be called with a DOM node and a callback function
+(a possible composite of a filter function described below, and an event handler).
+
+Such composite event functions can be used directly with `on()`, or registered with it using a name.
+All you have to do is to add it to a dictionary `on.events`:
+
+```js
+function buttonEvent (node, callback) {
+  return on.makeMultiHandle([
+    on(node, 'click', callback),
+    on(node, 'keyup:Enter', callback)
+  ]);
+}
+
+on.events.button = buttonEvent;
+
+// now we can:
+
+var handle = on(node, 'button', handler);
+```
+
+Named synthetic events can be used in multiple event types described above.
+
+The library comes with two synthetic events prepulated: `"button"`, and `"clickoff"`.
+
+### `clickoff`
+
+There is a custom `clickoff` event, to detect if you've clicked anywhere in the document
+other than the passed node. Useful for menus and modals.
+
+```js
+ var handle = on(node, 'clickoff', callback);
+ handle.resume();
+ //  callback fires if something other than node
+ // or its children are clicked
+```
+**NOTE**: _a clickoff event starts paused due to potential side effects. You typically don't want the event
+to be listened to and fired until some other event has been triggered, like the opening of a modal._
+
+### Multiple Key Events
+
+A special multi-event can be used to listen for certain key strokes:
+
+```js
+on(input, 'keyup:Enter,Escape, ,Backspace', handler);
+on(input, 'keydown:a,b,c,d,A,B,C,D', handler);
+```
+
+**NOTE**: _multiple key events incompatible with multiple event types described above. Do not use them together._
 
 ## Additional Features
 
 `on.emit`: a convenience function to generate events on nodes:
-```jsx harmony
+
+```js
 on.emit(node, 'click', {value: 'hello'});
 ```
-`on.fire`: generates [Custom Events](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent):
-```jsx harmony
-on.fire(node, 'toggle-panel', {value: 'open'});
 
+`on.fire`: generates [Custom Events](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent):
+
+```js
+on.fire(node, 'toggle-panel', {value: 'open'});
 ```
-    
-on does not need to have a node passed to it - you can pass an element ID:
-```jsx harmony
+
+`on()` does not need to have a node passed to it - you can pass an element ID:
+
+```js
 on('mynode', 'click', callback);
 ```
-on.makeMultiHandle`: accepts an array and returns a single handle to operate on all at once:
-```jsx harmony
+
+`on.makeMultiHandle`: accepts an array and returns a single handle to operate on all at once:
+
+```js
 var handle = on.makeMultiHandle([
     on(node, 'mousedown', callback1),
     on(node, 'mouseup', callback2)
@@ -143,20 +219,44 @@ var handle = on.makeMultiHandle([
 handle.pause();
 ```
 
-`on.once`: Will remove itself after one event has fired:
-```jsx harmony
+`on.once`: will remove itself after one event has fired:
+
+```js
 on.once(node, 'click', function(){
     console.log('fires only once');
 });
-on.emit(node, 'click');
-on.emit(node, 'click');
+on.emit(node, 'click'); // fires only once
+on.emit(node, 'click'); //
 ```
+
+It still returns a handle though.
 
 `on.closest` is a polyfilled version of [the spec](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest),
  which finds an ascendant element which matches a selector:
-```jsx harmony
+
+```js
 var correctAscendant =  on.closest(node, '.foo');
 ```
+
+`on.matches` is an actual name of [matches()](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches)
+function found dynamically in the browser. You can use it for your own needs:
+
+```js
+if (node[on.matches]('.header')) {
+  // ...
+}
+```
+
+`on.onDomEvent(node, eventName, callback)` is a simple `on()`-like function,
+which unconditionally and without any preprocessing sets an
+event handler on a node, and returns a handle. Its parameters:
+
+* `node` &mdash; a valid DOM node.
+* `eventName` &mdash; an event name as a string. No synthetic events are allowed.
+* `callback` &mdash; a standard event handling function.
+
+This function helps to write synthetic events. It is used to avoid possible loops, and ensures
+that standard DOM events can be handled directly.
 
 ## License
 

--- a/dist/on.min.js
+++ b/dist/on.min.js
@@ -2,20 +2,12 @@
 "function" == typeof customLoader ? customLoader(factory, "on") : "function" == typeof define && define.amd ? define([], factory) : "object" == typeof exports ? module.exports = factory() : root.returnExports = window.on = factory();
 }(this, function() {
 "use strict";
-function closest(element, selector, parent) {
-for (;element; ) {
-if (element[matches] && element[matches](selector)) return element;
-if (element === parent) break;
-element = element.parentElement;
-}
-return null;
-}
 function on(node, eventName, filter, handler) {
 "string" == typeof node && (node = getNodeById(node));
 var callback = makeCallback(node, filter, handler);
 if ("function" == typeof eventName) return eventName(node, callback);
 var keyEvent = /^(keyup|keydown):(.+)$/.exec(eventName);
-return keyEvent ? on(node, onKeyEvent(keyEvent[1], new RegExp(keyEvent[2].split(",").join("|"))), callback) : /,/.test(eventName) ? makeMultiHandle(eventName.split(",").map(function(name) {
+return keyEvent ? onKeyEvent(keyEvent[1], new RegExp(keyEvent[2].split(",").join("|")))(node, callback) : /,/.test(eventName) ? on.makeMultiHandle(eventName.split(",").map(function(name) {
 return name.trim();
 }).filter(function(name) {
 return name;
@@ -23,7 +15,10 @@ return name;
 return on(node, name, callback);
 })) : Object.prototype.hasOwnProperty.call(on.events, eventName) ? on.events[eventName](node, callback) : "load" === eventName && "img" === node.tagName.toLowerCase() ? onImageLoad(node, callback) : "wheel" !== eventName || (callback = normalizeWheelEvent(callback), 
 hasWheel) ? (/^key/.test(eventName) && (callback = normalizeKeyEvent(callback)), 
-node.addEventListener(eventName, callback, !1), handle = {
+on.onDomEvent(node, eventName, callback)) : on.makeMultiHandle([ on(node, "DOMMouseScroll", callback), on(node, "mousewheel", callback) ]);
+}
+function onDomEvent(node, eventName, callback) {
+return node.addEventListener(eventName, callback, !1), {
 remove: function() {
 node.removeEventListener(eventName, callback, !1), node = callback = null, this.remove = this.pause = this.resume = function() {};
 },
@@ -33,25 +28,33 @@ node.removeEventListener(eventName, callback, !1);
 resume: function() {
 node.addEventListener(eventName, callback, !1);
 }
-}, handle) : makeMultiHandle([ on(node, "DOMMouseScroll", callback), on(node, "mousewheel", callback) ]);
-}
-function onImageLoad(img, callback) {
-function onImageLoad(e) {
-var h = setInterval(function() {
-img.naturalWidth && (e.width = img.naturalWidth, e.naturalWidth = img.naturalWidth, 
-e.height = img.naturalHeight, e.naturalHeight = img.naturalHeight, callback(e), 
-clearInterval(h));
-}, 100);
-img.removeEventListener("load", onImageLoad), img.removeEventListener("error", callback);
-}
-return img.addEventListener("load", onImageLoad), img.addEventListener("error", callback), 
-{
-pause: function() {},
-resume: function() {},
-remove: function() {
-img.removeEventListener("load", onImageLoad), img.removeEventListener("error", callback);
-}
 };
+}
+function onImageLoad(node, callback) {
+function onImageLoad(e) {
+var interval = setInterval(function() {
+(node.naturalWidth || node.naturalHeight) && (e.width = e.naturalWidth = node.naturalWidth, 
+e.height = e.naturalHeight = node.naturalHeight, callback(e), clearInterval(interval));
+}, 100);
+handle.remove();
+}
+var handle = on.makeMultiHandle([ on.onDomEvent(node, "load", onImageLoad), on(node, "error", callback) ]);
+return handle;
+}
+function onKeyEvent(keyEventName, re) {
+return function(node, callback) {
+return on(node, keyEventName, function(e) {
+re.test(e.key) && callback(e);
+});
+};
+}
+function closest(element, selector, parent) {
+for (;element; ) {
+if (element[on.matches] && element[on.matches](selector)) return element;
+if (element === parent) break;
+element = element.parentElement;
+}
+return null;
 }
 function mix(object, value) {
 if (!value) return object;
@@ -78,7 +81,7 @@ XLR8 = 0;
 }
 function closestFilter(element, selector) {
 return function(e) {
-return closest(e.target, selector, element);
+return on.closest(e.target, selector, element);
 };
 }
 function makeMultiHandle(handles) {
@@ -112,16 +115,9 @@ var result = filter(e);
 result && (e.filteredTarget = result, handler(e, result));
 }) : filter || handler;
 }
-var INVALID_PROPS, matches, mouseWheelHandle, hasWheel = function() {
-var isIE = navigator.userAgent.indexOf("Trident") > -1, div = document.createElement("div");
-return "onwheel" in div || "wheel" in div || isIE && document.implementation.hasFeature("Events.wheel", "3.0");
-}(), isWin = navigator.userAgent.indexOf("Windows") > -1, FACTOR = isWin ? 10 : .1, XLR8 = 0;
-[ "matches", "matchesSelector", "webkit", "moz", "ms", "o" ].some(function(name) {
-return name.length < 7 && (name += "MatchesSelector"), !!Element.prototype[name] && (matches = name, 
-!0);
-}), on.events = {
+on.events = {
 button: function(node, callback) {
-return makeMultiHandle([ on(node, "click", callback), on(node, "keyup:Enter", callback) ]);
+return on.makeMultiHandle([ on(node, "click", callback), on(node, "keyup:Enter", callback) ]);
 },
 clickoff: function(node, callback) {
 var bHandle = on(node.ownerDocument.documentElement, "click", function(e) {
@@ -144,7 +140,15 @@ bHandle.remove(), this.state = "removed";
 return handle.pause(), handle;
 }
 };
-var INVALID_PROPS = {
+var matches, hasWheel = function() {
+var isIE = navigator.userAgent.indexOf("Trident") > -1, div = document.createElement("div");
+return "onwheel" in div || "wheel" in div || isIE && document.implementation.hasFeature("Events.wheel", "3.0");
+}();
+[ "matches", "matchesSelector", "webkit", "moz", "ms", "o" ].some(function(name) {
+return name.length < 7 && (name += "MatchesSelector"), !!Element.prototype[name] && (matches = name, 
+!0);
+});
+var mouseWheelHandle, INVALID_PROPS = {
 isTrusted: 1
 }, ieKeys = {
 Up: "ArrowUp",
@@ -154,7 +158,7 @@ Right: "ArrowRight",
 Esc: "Escape",
 Spacebar: " ",
 Win: "Command"
-};
+}, FACTOR = navigator.userAgent.indexOf("Windows") > -1 ? 10 : .1, XLR8 = 0;
 return on.once = function(node, eventName, filter, callback) {
 var h;
 return h = filter && callback ? on(node, eventName, filter, function() {
@@ -172,6 +176,6 @@ var event = node.ownerDocument.createEvent("CustomEvent");
 return event.initCustomEvent(eventName, !!bubbles, !0, eventDetail), node.dispatchEvent(event);
 }, on.isAlphaNumeric = function(str) {
 return /^[0-9a-z]$/i.test(str);
-}, on.makeMultiHandle = makeMultiHandle, on.closest = closest, on.matches = matches, 
-on;
+}, on.makeMultiHandle = makeMultiHandle, on.onDomEvent = onDomEvent, on.closest = closest, 
+on.matches = matches, on;
 });

--- a/dist/on.min.js
+++ b/dist/on.min.js
@@ -1,6 +1,5 @@
 !function(root, factory) {
-"function" == typeof customLoader ? customLoader(factory, "on") : "function" == typeof define && define.amd ? define([], factory) : "object" == typeof exports ? module.exports = factory() : (root.returnExports = factory(), 
-window.on = factory());
+"function" == typeof customLoader ? customLoader(factory, "on") : "function" == typeof define && define.amd ? define([], factory) : "object" == typeof exports ? module.exports = factory() : root.returnExports = window.on = factory();
 }(this, function() {
 "use strict";
 function closest(element, selector, parent) {
@@ -10,6 +9,72 @@ if (element === parent) break;
 element = element.parentElement;
 }
 return null;
+}
+function on(node, eventName, filter, handler) {
+"string" == typeof node && (node = getNodeById(node));
+var callback = makeCallback(node, filter, handler);
+if ("function" == typeof eventName) return eventName(node, callback);
+var keyEvent = /^(keyup|keydown):(.+)$/.exec(eventName);
+return keyEvent ? on(node, onKeyEvent(keyEvent[1], new RegExp(keyEvent[2].split(",").join("|"))), callback) : /,/.test(eventName) ? makeMultiHandle(eventName.split(",").map(function(name) {
+return name.trim();
+}).filter(function(name) {
+return name;
+}).map(function(name) {
+return on(node, name, callback);
+})) : Object.prototype.hasOwnProperty.call(on.events, eventName) ? on.events[eventName](node, callback) : "load" === eventName && "img" === node.tagName.toLowerCase() ? onImageLoad(node, callback) : "wheel" !== eventName || (callback = normalizeWheelEvent(callback), 
+hasWheel) ? (/^key/.test(eventName) && (callback = normalizeKeyEvent(callback)), 
+node.addEventListener(eventName, callback, !1), handle = {
+remove: function() {
+node.removeEventListener(eventName, callback, !1), node = callback = null, this.remove = this.pause = this.resume = function() {};
+},
+pause: function() {
+node.removeEventListener(eventName, callback, !1);
+},
+resume: function() {
+node.addEventListener(eventName, callback, !1);
+}
+}, handle) : makeMultiHandle([ on(node, "DOMMouseScroll", callback), on(node, "mousewheel", callback) ]);
+}
+function onImageLoad(img, callback) {
+function onImageLoad(e) {
+var h = setInterval(function() {
+img.naturalWidth && (e.width = img.naturalWidth, e.naturalWidth = img.naturalWidth, 
+e.height = img.naturalHeight, e.naturalHeight = img.naturalHeight, callback(e), 
+clearInterval(h));
+}, 100);
+img.removeEventListener("load", onImageLoad), img.removeEventListener("error", callback);
+}
+return img.addEventListener("load", onImageLoad), img.addEventListener("error", callback), 
+{
+pause: function() {},
+resume: function() {},
+remove: function() {
+img.removeEventListener("load", onImageLoad), img.removeEventListener("error", callback);
+}
+};
+}
+function mix(object, value) {
+if (!value) return object;
+if ("object" == typeof value) for (var key in value) INVALID_PROPS[key] || (object[key] = value[key]); else object.value = value;
+return object;
+}
+function normalizeKeyEvent(callback) {
+return function(e) {
+if (ieKeys[e.key]) {
+var fakeEvent = mix({}, e);
+fakeEvent.key = ieKeys[e.key], callback(fakeEvent);
+} else callback(e);
+};
+}
+function normalizeWheelEvent(callback) {
+return function(e) {
+XLR8 += FACTOR;
+var deltaY = Math.max(-1, Math.min(1, e.wheelDeltaY || e.deltaY)), deltaX = Math.max(-10, Math.min(10, e.wheelDeltaX || e.deltaX));
+deltaY = deltaY <= 0 ? deltaY - XLR8 : deltaY + XLR8, e.delta = deltaY, e.wheelY = deltaY, 
+e.wheelX = deltaX, clearTimeout(mouseWheelHandle), mouseWheelHandle = setTimeout(function() {
+XLR8 = 0;
+}, 300), callback(e);
+};
 }
 function closestFilter(element, selector) {
 return function(e) {
@@ -36,12 +101,33 @@ h.resume && h.resume();
 }
 };
 }
-function onClickoff(node, callback) {
-var handle, bHandle = on(document.body, "click", function(event) {
-var target = event.target;
-1 !== target.nodeType && (target = target.parentNode), target && !node.contains(target) && callback(event);
-});
-return handle = {
+function getNodeById(id) {
+var node = document.getElementById(id);
+return node || console.error("`on` Could not find:", id), node;
+}
+function makeCallback(node, filter, handler) {
+return filter && handler ? ("string" == typeof filter && (filter = closestFilter(node, filter)), 
+function(e) {
+var result = filter(e);
+result && (e.filteredTarget = result, handler(e, result));
+}) : filter || handler;
+}
+var INVALID_PROPS, matches, mouseWheelHandle, hasWheel = function() {
+var isIE = navigator.userAgent.indexOf("Trident") > -1, div = document.createElement("div");
+return "onwheel" in div || "wheel" in div || isIE && document.implementation.hasFeature("Events.wheel", "3.0");
+}(), isWin = navigator.userAgent.indexOf("Windows") > -1, FACTOR = isWin ? 10 : .1, XLR8 = 0;
+[ "matches", "matchesSelector", "webkit", "moz", "ms", "o" ].some(function(name) {
+return name.length < 7 && (name += "MatchesSelector"), !!Element.prototype[name] && (matches = name, 
+!0);
+}), on.events = {
+button: function(node, callback) {
+return makeMultiHandle([ on(node, "click", callback), on(node, "keyup:Enter", callback) ]);
+},
+clickoff: function(node, callback) {
+var bHandle = on(node.ownerDocument.documentElement, "click", function(e) {
+var target = e.target;
+1 !== target.nodeType && (target = target.parentNode), target && !node.contains(target) && callback(e);
+}), handle = {
 state: "resumed",
 resume: function() {
 setTimeout(function() {
@@ -54,101 +140,13 @@ bHandle.pause(), this.state = "paused";
 remove: function() {
 bHandle.remove(), this.state = "removed";
 }
-}, handle.pause(), handle;
-}
-function onImageLoad(img, callback) {
-function onImageLoad(e) {
-var h = setInterval(function() {
-img.naturalWidth && (e.width = img.naturalWidth, e.naturalWidth = img.naturalWidth, 
-e.height = img.naturalHeight, e.naturalHeight = img.naturalHeight, callback(e), 
-clearInterval(h));
-}, 100);
-img.removeEventListener("load", onImageLoad), img.removeEventListener("error", callback);
-}
-return img.addEventListener("load", onImageLoad), img.addEventListener("error", callback), 
-{
-pause: function() {},
-resume: function() {},
-remove: function() {
-img.removeEventListener("load", onImageLoad), img.removeEventListener("error", callback);
+};
+return handle.pause(), handle;
 }
 };
-}
-function getNode(str) {
-if ("string" != typeof str) return str;
-var node = document.getElementById(str);
-return node || console.error("`on` Could not find:", str), node;
-}
-function normalizeKeyEvent(callback) {
-return function(e) {
-if (ieKeys[e.key]) {
-var fakeEvent = mix({}, e);
-fakeEvent.key = ieKeys[e.key], callback(fakeEvent);
-} else callback(e);
-};
-}
-function normalizeWheelEvent(callback) {
-return function(e) {
-XLR8 += FACTOR;
-var deltaY = Math.max(-1, Math.min(1, e.wheelDeltaY || e.deltaY)), deltaX = Math.max(-10, Math.min(10, e.wheelDeltaX || e.deltaX));
-deltaY = deltaY <= 0 ? deltaY - XLR8 : deltaY + XLR8, e.delta = deltaY, e.wheelY = deltaY, 
-e.wheelX = deltaX, clearTimeout(mouseWheelHandle), mouseWheelHandle = setTimeout(function() {
-XLR8 = 0;
-}, 300), callback(e);
-};
-}
-function isMultiKey(eventName) {
-return /,/.test(eventName) && !/click|mouse|resize|scroll/.test(eventName);
-}
-function keysToRegExp(eventName) {
-return new RegExp(eventName.replace("keydown:", "").replace("keyup:", "").split(",").join("|"));
-}
-function on(node, eventName, filter, handler) {
-var callback, handles, handle, keyRegExp;
-if (isMultiKey(eventName) && (keyRegExp = keysToRegExp(eventName), callback = function(e) {
-keyRegExp.test(e.key) && (handler || filter)(e);
-}, eventName = /keydown/.test(eventName) ? "keydown" : "keyup"), /,/.test(eventName)) return handles = [], 
-eventName.split(",").forEach(function(eStr) {
-handles.push(on(node, eStr.trim(), filter, handler));
-}), makeMultiHandle(handles);
-if ("button" === eventName) return makeMultiHandle([ on(node, "click", filter, handle), on(node, "keyup:Enter", filter, handle) ]);
-if (node = getNode(node), filter && handler ? ("string" == typeof filter && (filter = closestFilter(node, filter)), 
-callback = function(e) {
-var result = filter(e);
-result && (e.filteredTarget = result, handler(e, result));
-}) : callback || (callback = filter || handler), "clickoff" === eventName) return onClickoff(node, callback);
-if ("load" === eventName && "img" === node.localName) return onImageLoad(node, callback);
-if ("wheel" === eventName) {
-if (!hasWheel) return makeMultiHandle([ on(node, "DOMMouseScroll", normalizeWheelEvent(callback)), on(node, "mousewheel", normalizeWheelEvent(callback)) ]);
-callback = normalizeWheelEvent(callback);
-}
-return /key/.test(eventName) && (callback = normalizeKeyEvent(callback)), node.addEventListener(eventName, callback, !1), 
-handle = {
-remove: function() {
-node.removeEventListener(eventName, callback, !1), node = callback = null, this.remove = this.pause = this.resume = function() {};
-},
-pause: function() {
-node.removeEventListener(eventName, callback, !1);
-},
-resume: function() {
-node.addEventListener(eventName, callback, !1);
-}
-};
-}
-function mix(object, value) {
-if (!value) return object;
-if ("object" == typeof value) for (var key in value) INVALID_PROPS[key] || (object[key] = value[key]); else object.value = value;
-return object;
-}
-var INVALID_PROPS, matches, mouseWheelHandle, hasWheel = function() {
-var isIE = navigator.userAgent.indexOf("Trident") > -1, div = document.createElement("div");
-return "onwheel" in div || "wheel" in div || isIE && document.implementation.hasFeature("Events.wheel", "3.0");
-}(), isWin = navigator.userAgent.indexOf("Windows") > -1, FACTOR = isWin ? 10 : .1, XLR8 = 0;
-[ "matches", "matchesSelector", "webkit", "moz", "ms", "o" ].some(function(name) {
-return name.length < 7 && (name += "MatchesSelector"), !!Element.prototype[name] && (matches = name, 
-!0);
-});
-var ieKeys = {
+var INVALID_PROPS = {
+isTrusted: 1
+}, ieKeys = {
 Up: "ArrowUp",
 Down: "ArrowDown",
 Left: "ArrowLeft",
@@ -164,21 +162,16 @@ callback.apply(window, arguments), h.remove();
 }) : on(node, eventName, function() {
 filter.apply(window, arguments), h.remove();
 });
-}, INVALID_PROPS = {
-isTrusted: 1
 }, on.emit = function(node, eventName, value) {
-node = getNode(node);
-var event = document.createEvent("HTMLEvents");
+node = "string" == typeof node ? getNodeById(node) : node;
+var event = node.ownerDocument.createEvent("HTMLEvents");
 return event.initEvent(eventName, !0, !0), node.dispatchEvent(mix(event, value));
 }, on.fire = function(node, eventName, eventDetail, bubbles) {
-var event = document.createEvent("CustomEvent");
+node = "string" == typeof node ? getNodeById(node) : node;
+var event = node.ownerDocument.createEvent("CustomEvent");
 return event.initCustomEvent(eventName, !!bubbles, !0, eventDetail), node.dispatchEvent(event);
 }, on.isAlphaNumeric = function(str) {
-if (str.length > 1) return !1;
-if (" " === str) return !1;
-if (!isNaN(Number(str))) return !0;
-var code = str.toLowerCase().charCodeAt(0);
-return code >= 97 && code <= 122;
+return /^[0-9a-z]$/i.test(str);
 }, on.makeMultiHandle = makeMultiHandle, on.closest = closest, on.matches = matches, 
 on;
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1085 @@
+{
+ "name": "on",
+ "version": "2.0.1",
+ "lockfileVersion": 1,
+ "requires": true,
+ "dependencies": {
+  "abbrev": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+   "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+   "dev": true
+  },
+  "align-text": {
+   "version": "0.1.4",
+   "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+   "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+   "dev": true,
+   "requires": {
+    "kind-of": "3.2.2",
+    "longest": "1.0.1",
+    "repeat-string": "1.6.1"
+   }
+  },
+  "ansi-regex": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+   "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+   "dev": true
+  },
+  "ansi-styles": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+   "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+   "dev": true
+  },
+  "argparse": {
+   "version": "1.0.9",
+   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+   "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+   "dev": true,
+   "requires": {
+    "sprintf-js": "1.0.3"
+   }
+  },
+  "array-find-index": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+   "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+   "dev": true
+  },
+  "async": {
+   "version": "1.5.2",
+   "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+   "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+   "dev": true
+  },
+  "balanced-match": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+   "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+   "dev": true
+  },
+  "brace-expansion": {
+   "version": "1.1.8",
+   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+   "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+   "dev": true,
+   "requires": {
+    "balanced-match": "1.0.0",
+    "concat-map": "0.0.1"
+   }
+  },
+  "browserify-zlib": {
+   "version": "0.1.4",
+   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+   "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+   "dev": true,
+   "requires": {
+    "pako": "0.2.9"
+   }
+  },
+  "builtin-modules": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+   "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+   "dev": true
+  },
+  "camelcase": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+   "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+   "dev": true
+  },
+  "camelcase-keys": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+   "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+   "dev": true,
+   "requires": {
+    "camelcase": "2.1.1",
+    "map-obj": "1.0.1"
+   }
+  },
+  "center-align": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+   "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+   "dev": true,
+   "requires": {
+    "align-text": "0.1.4",
+    "lazy-cache": "1.0.4"
+   }
+  },
+  "chalk": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+   "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+   "dev": true,
+   "requires": {
+    "ansi-styles": "2.2.1",
+    "escape-string-regexp": "1.0.5",
+    "has-ansi": "2.0.0",
+    "strip-ansi": "3.0.1",
+    "supports-color": "2.0.0"
+   }
+  },
+  "cliui": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+   "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+   "dev": true,
+   "requires": {
+    "center-align": "0.1.3",
+    "right-align": "0.1.3",
+    "wordwrap": "0.0.2"
+   }
+  },
+  "coffee-script": {
+   "version": "1.10.0",
+   "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz",
+   "integrity": "sha1-EpOLz5vhlI+gBvkuDEyegXBRCMA=",
+   "dev": true
+  },
+  "colors": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+   "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+   "dev": true
+  },
+  "concat-map": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+   "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+   "dev": true
+  },
+  "concat-stream": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+   "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+   "dev": true,
+   "requires": {
+    "inherits": "2.0.3",
+    "readable-stream": "2.3.3",
+    "typedarray": "0.0.6"
+   }
+  },
+  "core-util-is": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+   "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+   "dev": true
+  },
+  "currently-unhandled": {
+   "version": "0.4.1",
+   "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+   "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+   "dev": true,
+   "requires": {
+    "array-find-index": "1.0.2"
+   }
+  },
+  "dateformat": {
+   "version": "1.0.12",
+   "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+   "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+   "dev": true,
+   "requires": {
+    "get-stdin": "4.0.1",
+    "meow": "3.7.0"
+   }
+  },
+  "decamelize": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+   "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+   "dev": true
+  },
+  "define-properties": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+   "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+   "dev": true,
+   "requires": {
+    "foreach": "2.0.5",
+    "object-keys": "1.0.11"
+   }
+  },
+  "error-ex": {
+   "version": "1.3.1",
+   "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+   "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+   "dev": true,
+   "requires": {
+    "is-arrayish": "0.2.1"
+   }
+  },
+  "escape-string-regexp": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+   "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+   "dev": true
+  },
+  "esprima": {
+   "version": "2.7.3",
+   "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+   "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+   "dev": true
+  },
+  "eventemitter2": {
+   "version": "0.4.14",
+   "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+   "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+   "dev": true
+  },
+  "exit": {
+   "version": "0.1.2",
+   "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+   "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+   "dev": true
+  },
+  "figures": {
+   "version": "1.7.0",
+   "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+   "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+   "dev": true,
+   "requires": {
+    "escape-string-regexp": "1.0.5",
+    "object-assign": "4.1.1"
+   }
+  },
+  "find-up": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+   "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+   "dev": true,
+   "requires": {
+    "path-exists": "2.1.0",
+    "pinkie-promise": "2.0.1"
+   }
+  },
+  "findup-sync": {
+   "version": "0.3.0",
+   "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+   "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+   "dev": true,
+   "requires": {
+    "glob": "5.0.15"
+   },
+   "dependencies": {
+    "glob": {
+     "version": "5.0.15",
+     "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+     "dev": true,
+     "requires": {
+      "inflight": "1.0.6",
+      "inherits": "2.0.3",
+      "minimatch": "3.0.4",
+      "once": "1.4.0",
+      "path-is-absolute": "1.0.1"
+     }
+    }
+   }
+  },
+  "foreach": {
+   "version": "2.0.5",
+   "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+   "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+   "dev": true
+  },
+  "fs.realpath": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+   "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+   "dev": true
+  },
+  "function-bind": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+   "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+   "dev": true
+  },
+  "get-stdin": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+   "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+   "dev": true
+  },
+  "getobject": {
+   "version": "0.1.0",
+   "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+   "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+   "dev": true
+  },
+  "glob": {
+   "version": "7.0.6",
+   "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+   "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+   "dev": true,
+   "requires": {
+    "fs.realpath": "1.0.0",
+    "inflight": "1.0.6",
+    "inherits": "2.0.3",
+    "minimatch": "3.0.4",
+    "once": "1.4.0",
+    "path-is-absolute": "1.0.1"
+   }
+  },
+  "graceful-fs": {
+   "version": "4.1.11",
+   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+   "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+   "dev": true
+  },
+  "grunt": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.1.tgz",
+   "integrity": "sha1-6HeHZOlEsY8yuw8QuQeEdcnftWs=",
+   "dev": true,
+   "requires": {
+    "coffee-script": "1.10.0",
+    "dateformat": "1.0.12",
+    "eventemitter2": "0.4.14",
+    "exit": "0.1.2",
+    "findup-sync": "0.3.0",
+    "glob": "7.0.6",
+    "grunt-cli": "1.2.0",
+    "grunt-known-options": "1.1.0",
+    "grunt-legacy-log": "1.0.0",
+    "grunt-legacy-util": "1.0.0",
+    "iconv-lite": "0.4.18",
+    "js-yaml": "3.5.5",
+    "minimatch": "3.0.4",
+    "nopt": "3.0.6",
+    "path-is-absolute": "1.0.1",
+    "rimraf": "2.2.8"
+   },
+   "dependencies": {
+    "grunt-cli": {
+     "version": "1.2.0",
+     "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
+     "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
+     "dev": true,
+     "requires": {
+      "findup-sync": "0.3.0",
+      "grunt-known-options": "1.1.0",
+      "nopt": "3.0.6",
+      "resolve": "1.1.7"
+     }
+    }
+   }
+  },
+  "grunt-contrib-uglify": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-2.3.0.tgz",
+   "integrity": "sha1-s9AmDr3WzvoS/y+Onh4ln33kIW8=",
+   "dev": true,
+   "requires": {
+    "chalk": "1.1.3",
+    "maxmin": "1.1.0",
+    "object.assign": "4.0.4",
+    "uglify-js": "2.8.29",
+    "uri-path": "1.0.0"
+   }
+  },
+  "grunt-known-options": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
+   "integrity": "sha1-pCdO6zL6dl2lp6OxcSYXzjsUQUk=",
+   "dev": true
+  },
+  "grunt-legacy-log": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.0.tgz",
+   "integrity": "sha1-+4bxgJhHvAfcR4Q/ns1srLYt8tU=",
+   "dev": true,
+   "requires": {
+    "colors": "1.1.2",
+    "grunt-legacy-log-utils": "1.0.0",
+    "hooker": "0.2.3",
+    "lodash": "3.10.1",
+    "underscore.string": "3.2.3"
+   }
+  },
+  "grunt-legacy-log-utils": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
+   "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
+   "dev": true,
+   "requires": {
+    "chalk": "1.1.3",
+    "lodash": "4.3.0"
+   },
+   "dependencies": {
+    "lodash": {
+     "version": "4.3.0",
+     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
+     "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
+     "dev": true
+    }
+   }
+  },
+  "grunt-legacy-util": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
+   "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
+   "dev": true,
+   "requires": {
+    "async": "1.5.2",
+    "exit": "0.1.2",
+    "getobject": "0.1.0",
+    "hooker": "0.2.3",
+    "lodash": "4.3.0",
+    "underscore.string": "3.2.3",
+    "which": "1.2.14"
+   },
+   "dependencies": {
+    "lodash": {
+     "version": "4.3.0",
+     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
+     "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
+     "dev": true
+    }
+   }
+  },
+  "gzip-size": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
+   "integrity": "sha1-Zs+LEBBHInuVus5uodoMF37Vwi8=",
+   "dev": true,
+   "requires": {
+    "browserify-zlib": "0.1.4",
+    "concat-stream": "1.6.0"
+   }
+  },
+  "has-ansi": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+   "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+   "dev": true,
+   "requires": {
+    "ansi-regex": "2.1.1"
+   }
+  },
+  "hooker": {
+   "version": "0.2.3",
+   "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+   "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+   "dev": true
+  },
+  "hosted-git-info": {
+   "version": "2.5.0",
+   "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+   "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+   "dev": true
+  },
+  "iconv-lite": {
+   "version": "0.4.18",
+   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+   "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
+   "dev": true
+  },
+  "indent-string": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+   "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+   "dev": true,
+   "requires": {
+    "repeating": "2.0.1"
+   }
+  },
+  "inflight": {
+   "version": "1.0.6",
+   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+   "dev": true,
+   "requires": {
+    "once": "1.4.0",
+    "wrappy": "1.0.2"
+   }
+  },
+  "inherits": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+   "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+   "dev": true
+  },
+  "is-arrayish": {
+   "version": "0.2.1",
+   "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+   "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+   "dev": true
+  },
+  "is-buffer": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+   "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+   "dev": true
+  },
+  "is-builtin-module": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+   "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+   "dev": true,
+   "requires": {
+    "builtin-modules": "1.1.1"
+   }
+  },
+  "is-finite": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+   "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+   "dev": true,
+   "requires": {
+    "number-is-nan": "1.0.1"
+   }
+  },
+  "is-utf8": {
+   "version": "0.2.1",
+   "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+   "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+   "dev": true
+  },
+  "isarray": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+   "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+   "dev": true
+  },
+  "isexe": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+   "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+   "dev": true
+  },
+  "js-yaml": {
+   "version": "3.5.5",
+   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
+   "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
+   "dev": true,
+   "requires": {
+    "argparse": "1.0.9",
+    "esprima": "2.7.3"
+   }
+  },
+  "kind-of": {
+   "version": "3.2.2",
+   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+   "dev": true,
+   "requires": {
+    "is-buffer": "1.1.5"
+   }
+  },
+  "lazy-cache": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+   "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+   "dev": true
+  },
+  "load-json-file": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+   "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+   "dev": true,
+   "requires": {
+    "graceful-fs": "4.1.11",
+    "parse-json": "2.2.0",
+    "pify": "2.3.0",
+    "pinkie-promise": "2.0.1",
+    "strip-bom": "2.0.0"
+   }
+  },
+  "lodash": {
+   "version": "3.10.1",
+   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+   "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+   "dev": true
+  },
+  "longest": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+   "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+   "dev": true
+  },
+  "loud-rejection": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+   "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+   "dev": true,
+   "requires": {
+    "currently-unhandled": "0.4.1",
+    "signal-exit": "3.0.2"
+   }
+  },
+  "map-obj": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+   "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+   "dev": true
+  },
+  "maxmin": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
+   "integrity": "sha1-cTZehKmd2Piz99X94vANHn9zvmE=",
+   "dev": true,
+   "requires": {
+    "chalk": "1.1.3",
+    "figures": "1.7.0",
+    "gzip-size": "1.0.0",
+    "pretty-bytes": "1.0.4"
+   }
+  },
+  "meow": {
+   "version": "3.7.0",
+   "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+   "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+   "dev": true,
+   "requires": {
+    "camelcase-keys": "2.1.0",
+    "decamelize": "1.2.0",
+    "loud-rejection": "1.6.0",
+    "map-obj": "1.0.1",
+    "minimist": "1.2.0",
+    "normalize-package-data": "2.4.0",
+    "object-assign": "4.1.1",
+    "read-pkg-up": "1.0.1",
+    "redent": "1.0.0",
+    "trim-newlines": "1.0.0"
+   }
+  },
+  "minimatch": {
+   "version": "3.0.4",
+   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+   "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+   "dev": true,
+   "requires": {
+    "brace-expansion": "1.1.8"
+   }
+  },
+  "minimist": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+   "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+   "dev": true
+  },
+  "nopt": {
+   "version": "3.0.6",
+   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+   "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+   "dev": true,
+   "requires": {
+    "abbrev": "1.1.0"
+   }
+  },
+  "normalize-package-data": {
+   "version": "2.4.0",
+   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+   "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+   "dev": true,
+   "requires": {
+    "hosted-git-info": "2.5.0",
+    "is-builtin-module": "1.0.0",
+    "semver": "5.4.1",
+    "validate-npm-package-license": "3.0.1"
+   }
+  },
+  "number-is-nan": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+   "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+   "dev": true
+  },
+  "object-assign": {
+   "version": "4.1.1",
+   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+   "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+   "dev": true
+  },
+  "object-keys": {
+   "version": "1.0.11",
+   "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+   "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+   "dev": true
+  },
+  "object.assign": {
+   "version": "4.0.4",
+   "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
+   "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+   "dev": true,
+   "requires": {
+    "define-properties": "1.1.2",
+    "function-bind": "1.1.0",
+    "object-keys": "1.0.11"
+   }
+  },
+  "once": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+   "dev": true,
+   "requires": {
+    "wrappy": "1.0.2"
+   }
+  },
+  "pako": {
+   "version": "0.2.9",
+   "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+   "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+   "dev": true
+  },
+  "parse-json": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+   "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+   "dev": true,
+   "requires": {
+    "error-ex": "1.3.1"
+   }
+  },
+  "path-exists": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+   "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+   "dev": true,
+   "requires": {
+    "pinkie-promise": "2.0.1"
+   }
+  },
+  "path-is-absolute": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+   "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+   "dev": true
+  },
+  "path-type": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+   "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+   "dev": true,
+   "requires": {
+    "graceful-fs": "4.1.11",
+    "pify": "2.3.0",
+    "pinkie-promise": "2.0.1"
+   }
+  },
+  "pify": {
+   "version": "2.3.0",
+   "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+   "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+   "dev": true
+  },
+  "pinkie": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+   "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+   "dev": true
+  },
+  "pinkie-promise": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+   "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+   "dev": true,
+   "requires": {
+    "pinkie": "2.0.4"
+   }
+  },
+  "pretty-bytes": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+   "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
+   "dev": true,
+   "requires": {
+    "get-stdin": "4.0.1",
+    "meow": "3.7.0"
+   }
+  },
+  "process-nextick-args": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+   "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+   "dev": true
+  },
+  "read-pkg": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+   "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+   "dev": true,
+   "requires": {
+    "load-json-file": "1.1.0",
+    "normalize-package-data": "2.4.0",
+    "path-type": "1.1.0"
+   }
+  },
+  "read-pkg-up": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+   "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+   "dev": true,
+   "requires": {
+    "find-up": "1.1.2",
+    "read-pkg": "1.1.0"
+   }
+  },
+  "readable-stream": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+   "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+   "dev": true,
+   "requires": {
+    "core-util-is": "1.0.2",
+    "inherits": "2.0.3",
+    "isarray": "1.0.0",
+    "process-nextick-args": "1.0.7",
+    "safe-buffer": "5.1.1",
+    "string_decoder": "1.0.3",
+    "util-deprecate": "1.0.2"
+   }
+  },
+  "redent": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+   "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+   "dev": true,
+   "requires": {
+    "indent-string": "2.1.0",
+    "strip-indent": "1.0.1"
+   }
+  },
+  "repeat-string": {
+   "version": "1.6.1",
+   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+   "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+   "dev": true
+  },
+  "repeating": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+   "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+   "dev": true,
+   "requires": {
+    "is-finite": "1.0.2"
+   }
+  },
+  "resolve": {
+   "version": "1.1.7",
+   "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+   "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+   "dev": true
+  },
+  "right-align": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+   "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+   "dev": true,
+   "requires": {
+    "align-text": "0.1.4"
+   }
+  },
+  "rimraf": {
+   "version": "2.2.8",
+   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+   "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+   "dev": true
+  },
+  "safe-buffer": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+   "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+   "dev": true
+  },
+  "semver": {
+   "version": "5.4.1",
+   "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+   "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+   "dev": true
+  },
+  "signal-exit": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+   "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+   "dev": true
+  },
+  "source-map": {
+   "version": "0.5.6",
+   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+   "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+   "dev": true
+  },
+  "spdx-correct": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+   "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+   "dev": true,
+   "requires": {
+    "spdx-license-ids": "1.2.2"
+   }
+  },
+  "spdx-expression-parse": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+   "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+   "dev": true
+  },
+  "spdx-license-ids": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+   "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+   "dev": true
+  },
+  "sprintf-js": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+   "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+   "dev": true
+  },
+  "string_decoder": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+   "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+   "dev": true,
+   "requires": {
+    "safe-buffer": "5.1.1"
+   }
+  },
+  "strip-ansi": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+   "dev": true,
+   "requires": {
+    "ansi-regex": "2.1.1"
+   }
+  },
+  "strip-bom": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+   "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+   "dev": true,
+   "requires": {
+    "is-utf8": "0.2.1"
+   }
+  },
+  "strip-indent": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+   "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+   "dev": true,
+   "requires": {
+    "get-stdin": "4.0.1"
+   }
+  },
+  "supports-color": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+   "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+   "dev": true
+  },
+  "trim-newlines": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+   "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+   "dev": true
+  },
+  "typedarray": {
+   "version": "0.0.6",
+   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+   "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+   "dev": true
+  },
+  "uglify-js": {
+   "version": "2.8.29",
+   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+   "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+   "dev": true,
+   "requires": {
+    "source-map": "0.5.6",
+    "uglify-to-browserify": "1.0.2",
+    "yargs": "3.10.0"
+   }
+  },
+  "uglify-to-browserify": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+   "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+   "dev": true,
+   "optional": true
+  },
+  "underscore.string": {
+   "version": "3.2.3",
+   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
+   "integrity": "sha1-gGmSYzZl1eX8tNsfs6hi62jp5to=",
+   "dev": true
+  },
+  "uri-path": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/uri-path/-/uri-path-1.0.0.tgz",
+   "integrity": "sha1-l0fwGDWJM8Md4PzP2C0TjmcmLjI=",
+   "dev": true
+  },
+  "util-deprecate": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+   "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+   "dev": true
+  },
+  "validate-npm-package-license": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+   "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+   "dev": true,
+   "requires": {
+    "spdx-correct": "1.0.2",
+    "spdx-expression-parse": "1.0.4"
+   }
+  },
+  "which": {
+   "version": "1.2.14",
+   "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+   "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+   "dev": true,
+   "requires": {
+    "isexe": "2.0.0"
+   }
+  },
+  "window-size": {
+   "version": "0.1.0",
+   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+   "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+   "dev": true
+  },
+  "wordwrap": {
+   "version": "0.0.2",
+   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+   "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+   "dev": true
+  },
+  "wrappy": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+   "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+   "dev": true
+  },
+  "yargs": {
+   "version": "3.10.0",
+   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+   "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+   "dev": true,
+   "requires": {
+    "camelcase": "1.2.1",
+    "cliui": "2.1.0",
+    "decamelize": "1.2.0",
+    "window-size": "0.1.0"
+   },
+   "dependencies": {
+    "camelcase": {
+     "version": "1.2.1",
+     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+     "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+     "dev": true
+    }
+   }
+  }
+ }
+}

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-	"name": "on",
-  "version": "2.0.1",
-  "author": "anm9tr@gmail.com",
-	"main":"dist/on.js",
-  "description": "A library for making DOM Node event handling simple",
-	"license": "MIT",
-    "readmeFilename": "README.md",
-	"repository": {
-        "type": "git",
-        "url": "git://github.com/clubajax/on.git"
-    },
-	"devDependencies": {
-		"grunt": "^1.0.1",
-    "grunt-contrib-uglify": "^2.3.0"
-	}
+ "name": "on",
+ "version": "2.1.0",
+ "author": "anm9tr@gmail.com",
+ "main": "dist/on.js",
+ "description": "A library for making DOM Node event handling simple",
+ "license": "MIT",
+ "readmeFilename": "README.md",
+ "repository": {
+  "type": "git",
+  "url": "git://github.com/clubajax/on.git"
+ },
+ "devDependencies": {
+  "grunt": "^1.0.1",
+  "grunt-contrib-uglify": "^2.3.0"
+ }
 }

--- a/src/on.js
+++ b/src/on.js
@@ -37,7 +37,7 @@
 
 		// handle multiple event types, like: on(node, 'mouseup, mousedown', callback);
 		if (/,/.test(eventName)) {
-			return makeMultiHandle(eventName.split(',').map(function (name) {
+			return on.makeMultiHandle(eventName.split(',').map(function (name) {
 				return name.trim();
 			}).filter(function (name) {
 				return name;
@@ -62,7 +62,7 @@
 			callback = normalizeWheelEvent(callback);
 			if (!hasWheel) {
 				// old Firefox, old IE, Chrome
-				return makeMultiHandle([
+				return on.makeMultiHandle([
 					on(node, 'DOMMouseScroll', callback),
 					on(node, 'mousewheel', callback)
 				]);
@@ -75,14 +75,14 @@
 		}
 
 		// default case
-		return onDomEvent(node, eventName, callback);
+		return on.onDomEvent(node, eventName, callback);
 	}
 
 	// registered functional events
 	on.events = {
 		// handle click and Enter
 		button: function (node, callback) {
-			return makeMultiHandle([
+			return on.makeMultiHandle([
 				on(node, 'click', callback),
 				on(node, 'keyup:Enter', callback)
 			]);
@@ -146,8 +146,8 @@
 	}
 
 	function onImageLoad (node, callback) {
-		var handle = makeMultiHandle([
-			onDomEvent(node, 'load', onImageLoad),
+		var handle = on.makeMultiHandle([
+			on.onDomEvent(node, 'load', onImageLoad),
 			on(node, 'error', callback)
 		]);
 
@@ -201,7 +201,7 @@
 
 	function closest (element, selector, parent) {
 		while (element) {
-			if (element[matches] && element[matches](selector)) {
+			if (element[on.matches] && element[on.matches](selector)) {
 				return element;
 			}
 			if (element === parent) {
@@ -388,6 +388,7 @@
 	};
 
 	on.makeMultiHandle = makeMultiHandle;
+	on.onDomEvent = onDomEvent; // use directly to prevent possible definition loops
 	on.closest = closest;
 	on.matches = matches;
 

--- a/src/on.js
+++ b/src/on.js
@@ -15,7 +15,7 @@
 
 	function on (node, eventName, filter, handler) {
 		// normalize parameters
-		if (typeof node == 'string') {
+		if (typeof node === 'string') {
 			node = getNodeById(node);
 		}
 
@@ -23,7 +23,7 @@
 		var callback = makeCallback(node, filter, handler);
 
 		// functional event
-		if (typeof eventName == 'function') {
+		if (typeof eventName === 'function') {
 			return eventName(node, callback);
 		}
 
@@ -273,7 +273,7 @@
 
 			deltaY = deltaY <= 0 ? deltaY - XLR8 : deltaY + XLR8;
 
-			e.delta = deltaY;
+			e.delta  = deltaY;
 			e.wheelY = deltaY;
 			e.wheelX = deltaX;
 
@@ -336,7 +336,7 @@
 
 	function makeCallback (node, filter, handler) {
 		if (filter && handler) {
-			if (typeof filter == 'string') {
+			if (typeof filter === 'string') {
 				filter = closestFilter(node, filter);
 			}
 			return function (e) {
@@ -369,14 +369,14 @@
 	};
 
 	on.emit = function (node, eventName, value) {
-		node = typeof node == 'string' ? getNodeById(node) : node;
+		node = typeof node === 'string' ? getNodeById(node) : node;
 		var event = node.ownerDocument.createEvent('HTMLEvents');
 		event.initEvent(eventName, true, true); // event type, bubbling, cancelable
 		return node.dispatchEvent(mix(event, value));
 	};
 
 	on.fire = function (node, eventName, eventDetail, bubbles) {
-		node = typeof node == 'string' ? getNodeById(node) : node;
+		node = typeof node === 'string' ? getNodeById(node) : node;
 		var event = node.ownerDocument.createEvent('CustomEvent');
 		event.initCustomEvent(eventName, !!bubbles, true, eventDetail); // event type, bubbling, cancelable, value
 		return node.dispatchEvent(event);

--- a/tests/on.html
+++ b/tests/on.html
@@ -45,156 +45,147 @@
 			padding: 3px;
 		}
 	</style>
-    <script src="../src/on.js"></script>
-
+  <script src="../src/on.js"></script>
 </head>
 <body>
-	<h1>on v2.0 test</h1>
+	<h1>on v2.1 test</h1>
 	<p>Results are in the console.</p>
-	
+
 	<p>Test Key Events</p>
 	<input id='inp' />
 
 	<p>Test Multi Key Events</p>
 	<input id='minp' />
 
-    <p>Test simple connections</p>
-    <button id=b1>clicker</button>
-    <button id=b2>pause clicker</button>
-    <button id=b3>resume clicker</button>
-    <button id=b4>cancel clicker</button>
-
-    <p>Test context</p>
-    <button id=cb1>clicker</button>
-    <button id=cm1>multi</button>
+  <p>Test simple connections</p>
+  <button id=b1>clicker</button>
+  <button id=b2>pause clicker</button>
+  <button id=b3>resume clicker</button>
+  <button id=b4>cancel clicker</button>
 
 	<p>Test Button Event</p>
 	<button id=b5>Click or Enter</button>
 
-    <p>Test css selectors</p>
-    <div id=css>
-        <span class='tab'><a href='#' >Tab 1</a></span>
-        <span class='tab'><a href='#' >Tab 2</a></span>
-        <span class='tab'><a href='#' >Tab 3</a></span>
-    </div>
-	
+  <p>Test css selectors</p>
+  <div id=css>
+    <span class='tab'><a href='#' >Tab 1</a></span>
+    <span class='tab'><a href='#' >Tab 2</a></span>
+    <span class='tab'><a href='#' >Tab 3</a></span>
+  </div>
+
 	<div id='mousewheeltest'>Test mousewheel</div>
-	
+
 	<div id='modal'>
 		Modal. Click in me, click out of me, mouse in and out of me.
 	</div>
 
 	<script>
-			console.log('on loaded');
-			var
-				on = window.on,
-				h1, h2, o, clickoff,
-				tabs = document.querySelectorAll('.tab'),
-				wheelNode = document.getElementById('mousewheeltest'),
-				modal = document.getElementById('modal');
+		console.log('on loaded');
+		var
+			on = window.on,
+			h1, h2, o, clickoff,
+			tabs = document.querySelectorAll('.tab'),
+			wheelNode = document.getElementById('mousewheeltest'),
+			modal = document.getElementById('modal');
 
-			// test mouse wheel normalization
-			on(wheelNode, 'wheel', function(e){
-				wheelNode.innerHTML = 'delta: ' + e.delta.toFixed(2)+ '<br>wheelY: ' + e.wheelY.toFixed(2)+ '<br>wheelX: ' + e.wheelX.toFixed(2);
-			});
+		// test mouse wheel normalization
+		on(wheelNode, 'wheel', function(e){
+			wheelNode.innerHTML = 'delta: ' + e.delta.toFixed(2)+ '<br>wheelY: ' + e.wheelY.toFixed(2)+ '<br>wheelX: ' + e.wheelX.toFixed(2);
+		});
 
-			// test modal clickoff special function
-			clickoff = on(modal, 'clickoff', function(){
-				modal.innerHTML = ('modal clickoff');	
-			});
-			clickoff.resume();
-
-
-			// test mouseemter/leave
-			// should be standard in all browsers
-			on('modal', 'mouseenter', function(){
-				modal.innerHTML = ('modal enter');	
-			});
-			on('modal', 'mouseleave', function(){
-				modal.innerHTML = ('modal leave');	
-			});
-			
-			// test CSS filters
-			on('css', 'click', '.tab', function(e, filteredTarget){
-				console.log('clicked tab', e.filteredTarget);
-			});
+		// test modal clickoff special function
+		clickoff = on(modal, 'clickoff', function(){
+			modal.innerHTML = ('modal clickoff');
+		});
+		clickoff.resume();
 
 
-			// test pause/remove handles
-			h1 = on('b1', 'click', function(){
-				console.log('[clicker]');
-			});
-			on('b2', 'click', function(){
-				h1.pause();
-				console.log('pause!');
-			});
-			on('b3', 'click', function(){
-				h1.resume();
-				console.log('resume!');
-			});
-			on('b4', 'click', function(){
-				h1.remove();
-				console.log('remove!');
-			});
+		// test mouseenter/leave
+		// should be standard in all browsers
+		on('modal', 'mouseenter', function(){
+			modal.innerHTML = ('modal enter');
+		});
+		on('modal', 'mouseleave', function(){
+			modal.innerHTML = ('modal leave');
+		});
 
-			// test button
-			on('b5', 'button', function () {
-				console.log('Exec Button');
-			});
+		// test CSS filters
+		on('css', 'click', '.tab', function(e, filteredTarget){
+			console.log('clicked tab', e.filteredTarget);
+		});
 
-			// test key handling
-			// expects the use of polyfill
-			on('inp', 'keydown', function(e){
-				console.log('keydown', e.key, e.keyCode, e);
-			});
-			on('inp', 'keyup', function(e){
-				//console.log('keyup', e.alphanumeric, e.key);
-			});
-			on('inp', 'keypress', function(e){
-				//console.log('keypress', e.alphanumeric, e.key);
-			});
 
-			// test multi key handling
-			on('minp', 'keydown:a,b,c, ,ArrowDown,ArrowUp,ArrowLeft,ArrowRight,Enter,Escape', function(e){
-				console.log('keydown', e.key);
+		// test pause/remove handles
+		h1 = on('b1', 'click', function(){
+			console.log('[clicker]');
+		});
+		on('b2', 'click', function(){
+			h1.pause();
+			console.log('pause!');
+		});
+		on('b3', 'click', function(){
+			h1.resume();
+			console.log('resume!');
+		});
+		on('b4', 'click', function(){
+			h1.remove();
+			console.log('remove!');
+		});
+
+		// test button
+		on('b5', 'button', function () {
+			console.log('Exec Button');
+		});
+
+		// test key handling
+		// expects the use of polyfill
+		on('inp', 'keydown', function(e){
+			console.log('keydown', e.key, e.keyCode, e);
+		});
+		on('inp', 'keyup', function(e){
+			//console.log('keyup', e.alphanumeric, e.key);
+		});
+		on('inp', 'keypress', function(e){
+			//console.log('keypress', e.alphanumeric, e.key);
+		});
+
+		// test multi key handling
+		on('minp', 'keydown:a,b,c, ,ArrowDown,ArrowUp,ArrowLeft,ArrowRight,Enter,Escape', function(e){
+			console.log('keydown', e.key);
+		});
+
+		function delay(fn){
+			setTimeout(fn, 300);
+		}
+
+		function testKeys(){
+			delay(function () {
+				on.emit('inp', 'keydown', {keyCode: 65, key: 'A'});
 			});
-
-			function delay(fn){
-				setTimeout(fn, 300);
-			}
-
-			function testKeys(){
+		}
+		function test(){
+			delay(function () {
+				on.emit('modal', 'mouseenter');
 				delay(function () {
-					on.emit('inp', 'keydown', {keyCode: 65, key: 'A'});
+					on.emit('modal', 'mouseleave');
 				});
-			}
-			function test(){
-				delay(function () {
-					on.emit('modal', 'mouseenter');
-					delay(function () {
-						on.emit('modal', 'mouseleave');
-					});
-				});
-				console.log('should see [clicker] twice:');
-				on.emit('b1', 'click');
-				on.emit('b2', 'click');
-				on.emit('b1', 'click');
-				on.emit('b1', 'click');
-				on.emit('b3', 'click');
-				on.emit('b1', 'click');
-				on.emit('b4', 'click');
-				on.emit('b1', 'click');
-				on.emit('b1', 'click');
+			});
+			console.log('should see [clicker] twice:');
+			on.emit('b1', 'click');
+			on.emit('b2', 'click');
+			on.emit('b1', 'click');
+			on.emit('b1', 'click');
+			on.emit('b3', 'click');
+			on.emit('b1', 'click');
+			on.emit('b4', 'click');
+			on.emit('b1', 'click');
+			on.emit('b1', 'click');
 
-				on.emit(tabs[0], 'click');
-				on.emit(tabs[1], 'click');
-				on.emit(tabs[2], 'click');
-
-
-
-			}
-			test();
-			testKeys();
-
-</script>
+			on.emit(tabs[0], 'click');
+			on.emit(tabs[1], 'click');
+			on.emit(tabs[2], 'click');
+		}
+		test();
+		testKeys();
+	</script>
 </html>


### PR DESCRIPTION
One new feature: events as functions. If an `eventName` is a function, it will be called with `node`, and `callback` (both will be normalized: `node` is always a node, not an id, and `callback` may encapsulate both `filter` and `handle`).

`on.events` is a dictionary of such functional events, which is checked automatically. Internal special cases are converted to functions. Examples: `'button'` is now an entry in `on.events`, as well as `'clickoff'`. It is possible to register more functions dynamically, or just supply them instead of `eventName`. That should be the preferred mechanism to create custom events (like gestures), and extend `on`.

Other than that nothing has changed. It is still 100% compatible with the previous version, and should be invisible for existing applications.

Look at the code, read TODOs, answer them, if it makes sense. Any questions --- you know how to find me. :-) If you feel the change is acceptable, I'll update README as well.